### PR TITLE
Add Luminor fund history scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # CodexRepository
+
+This repository contains utilities for working with pension fund data.
+
+## Download Luminor Tvari Ateitis Index history
+
+Run the provided script to download the fund's historical unit values and store them as a CSV file for use in Jupyter notebooks.
+
+```bash
+pip install -r requirements.txt
+python scripts/fetch_luminor_fund.py
+```
+
+The script saves the history to `data/luminor_tvari_ateitis_index.csv`.
+
+You can then load it in a notebook:
+
+```python
+import pandas as pd
+
+df = pd.read_csv("data/luminor_tvari_ateitis_index.csv")
+print(df.head())
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+requests

--- a/scripts/fetch_luminor_fund.py
+++ b/scripts/fetch_luminor_fund.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import requests
+from pathlib import Path
+
+URL = "https://www.luminor.lt/lt/rinkis-fonda?fund=22"
+
+def fetch_luminor_fund_history(url: str = URL) -> pd.DataFrame:
+    """Download Luminor Tvari Ateitis Index fund history and return DataFrame.
+
+    Parameters
+    ----------
+    url: str
+        Page that contains the fund history table.
+    """
+    headers = {"User-Agent": "Mozilla/5.0"}
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    tables = pd.read_html(response.text)
+    if not tables:
+        raise ValueError("No tables found in the fund history page")
+    # Assume the first table holds the historical values.
+    history = tables[0]
+    return history
+
+def save_history_to_csv(df: pd.DataFrame, path: str | Path) -> None:
+    """Save the DataFrame to CSV file."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+if __name__ == "__main__":
+    data_path = Path("data/luminor_tvari_ateitis_index.csv")
+    df = fetch_luminor_fund_history()
+    save_history_to_csv(df, data_path)
+    print(f"Saved {len(df)} rows to {data_path}")


### PR DESCRIPTION
## Summary
- add Python script to download Luminor Tvari Ateitis Index fund history and save to CSV
- document usage in README
- list requests and pandas in requirements

## Testing
- `python scripts/fetch_luminor_fund.py` (fails: ModuleNotFoundError: No module named 'pandas')
- `pip install pandas requests` (fails: ProxyError: Tunnel connection failed: 403 Forbidden)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee5ab47c08329be19702443608706